### PR TITLE
Resolve type evaluation on future parser and puppetserver

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@ class ossec::client(
   concat { '/var/ossec/etc/ossec.conf':
     owner   => 'root',
     group   => 'ossec',
-    mode    => 0440,
+    mode    => '0440',
     require => Package[$ossec::common::hidsagentpackage],
     notify  => Service[$ossec::common::hidsagentservice]
   }
@@ -56,7 +56,7 @@ class ossec::client(
   concat { '/var/ossec/etc/client.keys':
     owner   => 'root',
     group   => 'ossec',
-    mode    => 0640,
+    mode    => '0640',
     notify  => Service[$ossec::common::hidsagentservice],
     require => Package[$ossec::common::hidsagentpackage]
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,7 +45,7 @@ class ossec::server (
   concat { '/var/ossec/etc/ossec.conf':
     owner   => 'root',
     group   => 'ossec',
-    mode    => 0440,
+    mode    => '0440',
     require => Package[$ossec::common::hidsserverpackage],
     notify  => Service[$ossec::common::hidsserverservice]
   }
@@ -65,7 +65,7 @@ class ossec::server (
   concat { '/var/ossec/etc/client.keys':
     owner   => 'root',
     group   => 'ossec',
-    mode    => 0640,
+    mode    => '0640',
     notify  => Service[$ossec::common::hidsserverservice],
     require => Package[$ossec::common::hidsserverpackage],
   }


### PR DESCRIPTION
Module will not install under parser = future or on puppetserver without quoting octal permissions. 

See https://tickets.puppetlabs.com/browse/PUP-2731?jql=text%20~%20%22Fixnum%22