### PR TITLE
Make it work on Debian

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,7 @@ class ossec::client(
     'Debian' : {
       package { $ossec::common::hidsagentpackage:
         ensure  => installed,
-        require => Apt::Ppa['ppa:nicolas-zin/ossec-ubuntu'],
+        require => Apt::Source["alienvault"],
       }
     }
     'RedHat' : {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,7 @@ class ossec::client(
     'Debian' : {
       package { $ossec::common::hidsagentpackage:
         ensure  => installed,
-        require => Apt::Source["alienvault"],
+        require => Apt::Source['alienvault'],
       }
     }
     'RedHat' : {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,7 +16,7 @@ class ossec::server (
     'Debian' : {
       package { $ossec::common::hidsserverpackage:
         ensure  => installed,
-        require => Apt::Ppa['ppa:nicolas-zin/ossec-ubuntu'],
+        require => Apt::Source['alienvault'],
       }
     }
     'RedHat' : {


### PR DESCRIPTION
Require Apt::Source[alienvault] on Debian, in stead of Apt::Pla['ppa:nicolas-zin/ossec-ubuntu']
Resolves #10