### PR TITLE
Make it work on Debian

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,7 @@ class ossec::client(
     'Debian' : {
       package { $ossec::common::hidsagentpackage:
         ensure  => installed,
-        require => Apt::Ppa['ppa:nicolas-zin/ossec-ubuntu'],
+        require => Apt::Source["alienvault"],
       }
     }
     'RedHat' : {

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -2,7 +2,7 @@
 class ossec::common {
   case $::osfamily {
     'Debian' : {
-      $hidsagentservice  = 'ossec-hids-agent'
+      $hidsagentservice  = 'ossec'
       $hidsagentpackage  = 'ossec-hids-agent'
 
       case $::lsbdistcodename {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -16,7 +16,7 @@ class ossec::server (
     'Debian' : {
       package { $ossec::common::hidsserverpackage:
         ensure  => installed,
-        require => Apt::Ppa['ppa:nicolas-zin/ossec-ubuntu'],
+        require => Apt::Source["alienvault"],
       }
     }
     'RedHat' : {


### PR DESCRIPTION
Requiring a specific ppa source in both server and client for Debian obviously a mistake, since the common will assign the correct apt-source to the variable 'alienvault'.

On Debian, the agent init script is just called 'ossec', not 'ossec-hids-agent'

Making these changes makes the module actually execute successfully on our Debian servers.