### PR TITLE
Addlog changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The server is configured by installing the `ossec::server` class, and using opti
  * `ossec::command`        : to define active/response command (like `firewall-drop.sh`)
  * `ossec::activeresponse` : to link rules to active/response command
  * `ossec:: email_alert`   : to receive to other email adress specific group of rules information
+ * `ossec::addlog`         : to define additional log files to monitor
 
 ## Usage
 
@@ -42,6 +43,11 @@ ossec::activeresponse { 'blockWebattack':
   command_name => 'firewall-drop',
   ar_level     => 9,
   ar_rules_id  => [31153,31151]
+}
+
+ossec::addlog { 'monitorLogFile':
+  logfile => '/var/log/secure',
+  logtype => 'syslog'
 }
 ```
 
@@ -86,6 +92,11 @@ About active-response mechanism, check the documentation (and extends the functi
  * `$ar_level` (default: 7) between 0 and 16
  * `$ar_rules_id` (default: `[]`) list of rules id
  * `$ar_timeout` (default: 300) usually active reponse blocks for a certain amount of time.
+
+#### function ossec::addlog
+ * `$log_name`,
+ * `$logfile` /path/to/log/file
+ * `$logtype` (default: syslog) The ossec log_format of the file.  Valid values can be found in the [documentation](https://ossec-docs.readthedocs.org/en/latest/syntax/head_ossec_config.localfile.html#location).
 
 
 

--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -3,10 +3,10 @@ define ossec::addlog(
   $logfile,
   $logtype = 'syslog',
 ) {
-  concat::fragment { 'ossec.conf_20':
+  concat::fragment { "ossec.conf_20-${logfile}":
     target  => '/var/ossec/etc/ossec.conf',
     content => template('ossec/20_ossecLogfile.conf.erb'),
-    order   => 10,
+    order   => 20,
     notify  => Service[$ossec::common::hidsserverservice]
   }
 


### PR DESCRIPTION
* Originally puppet would complain about duplicate fragments named ossec.conf_20 when you attempted to use the addlog function more than once.  This change allows multiple uses of the addlog function by appending the logfile name to the fragment name.
* Fixed the order of the fragment created by the addlog function so that it matches what was implied by the fragment name.
* Added some documentation about the addlog function.