### PR TITLE
This adds support for CentOS 7 

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,17 +20,48 @@ class ossec::server (
       }
     }
     'RedHat' : {
-      package { 'mysql': ensure => present }
-      package { 'ossec-hids':
-        ensure   => installed,
-      }
-      package { $ossec::common::hidsserverpackage:
-        ensure  => installed,
-        require => Package['mysql'],
+      case $::operatingsystem {
+        'CentOS' : {
+          case $::operatingsystemmajrelease {
+            '7' : {
+              package { 'mariadb': ensure => present }
+              package { 'ossec-hids':
+                ensure   => installed,
+              }
+              package { $ossec::common::hidsserverpackage:
+                ensure  => installed,
+                require => Package['mariadb'],
+              }
+            }
+            'default' : {
+              package { 'mysql': ensure => present }
+              package { 'ossec-hids':
+                ensure   => installed,
+              }
+              package { $ossec::common::hidsserverpackage:
+                ensure  => installed,
+                require => Package['mysql'],
+              }
+            }
+          }
+        }
+        'RedHat' : {
+          package { $ossec::common::hidsserverpackage:
+            ensure  => installed,
+            require => Package['mysql'],
+          }
+          package { 'mysql': ensure => present }
+          package { 'ossec-hids':
+            ensure   => installed,
+          }
+          package { $ossec::common::hidsserverpackage:
+            ensure  => installed,
+            require => Package['mysql'],
+          }
+        }
       }
     }
     default: { fail('OS family not supported') }
-
   }
 
   service { $ossec::common::hidsserverservice:


### PR DESCRIPTION
CentOS 7 did away with mysql in favor of mariadb this just adds the extra logic to ensure the correct package.