### PR TITLE
change to make the logs directory writable

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -79,7 +79,7 @@ class ossec::client(
     require => Package[$ossec::common::hidsagentpackage],
     owner   => 'ossec',
     group   => 'ossec',
-    mode    => '0550',
+    mode    => '0750',
   }
 }
 


### PR DESCRIPTION
This should stop logrotate from complaining that it can't rotate the logfiles.