### PR TITLE
Various updates for the puppet-ossec module

### DIFF
--- a/manifests/agentkey.pp
+++ b/manifests/agentkey.pp
@@ -5,15 +5,17 @@ define ossec::agentkey(
   $agent_ip_address,
   $agent_seed = 'xaeS7ahf',
 ) {
-  if ! $agent_id { fail("ossec::agentkey: ${agent_id} is missing")}
+  if $agent_id {
+    $agentKey1 = ossec_md5("${agent_id} ${agent_seed}")
+    $agentKey2 = ossec_md5("${agent_name} ${agent_ip_address} ${agent_seed}")
 
-  $agentKey1 = ossec_md5("${agent_id} ${agent_seed}")
-  $agentKey2 = ossec_md5("${agent_name} ${agent_ip_address} ${agent_seed}")
-
-  concat::fragment { "var_ossec_etc_client.keys_${agent_name}_part":
-    target  => '/var/ossec/etc/client.keys',
-    order   => $agent_id,
-    content => "${agent_id} ${agent_name} ${agent_ip_address} ${agentKey1}${agentKey2}\n",
+    concat::fragment { "var_ossec_etc_client.keys_${agent_name}_part":
+      target  => '/var/ossec/etc/client.keys',
+      order   => $agent_id,
+      content => "${agent_id} ${agent_name} ${agent_ip_address} ${agentKey1}${agentKey2}\n",
+    }
+  } else {
+    notify{ "ossec::agentkey: ${agent_id} is missing": }
   }
-
 }
+

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -11,7 +11,7 @@ class ossec::client(
     'Debian' : {
       package { $ossec::common::hidsagentpackage:
         ensure  => installed,
-        require => Apt::Source['alienvault'],
+        require => Apt::Source['alienvault-ossec'],
       }
     }
     'RedHat' : {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -83,6 +83,12 @@ class ossec::client(
     mode    => '0755',
   }
 
+  exec { "agent-auth":
+    command   	=> "/var/ossec/bin/agent-auth -m $ossec_server_ip -A $::fqdn -D /var/ossec/",
+    creates   	=> "/var/ossec/etc/client.keys",
+    require   	=> Package[$ossec::common::hidsagentpackage]
+  }
+
   # SELinux
   if ($::osfamily == 'RedHat' and $selinux == true) {
     selinux::module { 'ossec-logrotate':

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -8,33 +8,16 @@ class ossec::common {
 
       case $::lsbdistcodename {
         /(lucid|precise|trusty)/: {
-          #$hidsserverservice = 'ossec-hids-server'
-          #$hidsserverpackage = 'ossec-hids-server'
-          #apt::ppa { 'ppa:nicolas-zin/ossec-ubuntu': }
-
           $hidsserverservice = 'ossec'
           $hidsserverpackage = 'ossec-hids'
 
-          #apt::source { 'alienvault':
-          #  ensure      => present,
-          #  comment     => 'This is the AlienVault Debian repository for Ossec',
-          #  location    => 'http://ossec.alienvault.com/repos/apt/debian',
-          #  release     => $::lsbdistcodename,
-          #  repos       => 'main',
-          #  include_src => false,
-          #  include_deb => true,
-          #  key         => '9A1B1C65',
-          #  key_source  => 'http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key',
-          #}
-
-          ::apt::source { 'alienvault-ossec':
+          apt::source { 'alienvault-ossec':
             ensure		=> present,
             comment		=> 'This is the AlienVault Ubuntu repository for Ossec',
             location	=> 'http://ossec.alienvault.com/repos/apt/ubuntu',
             release		=> $::lsbdistcodename,
             repos		=> 'main',
             key		=> {
-              #id		=> '9A1B1C65',
               id		=> '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
               source		=> 'http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key',
             },

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -49,7 +49,7 @@ class ossec::common {
           $hidsserverservice = 'ossec'
           $hidsserverpackage = 'ossec-hids'
 
-          apt::source { 'alienvault':
+          apt::source { 'alienvault-ossec':
             ensure      => present,
             comment     => 'This is the AlienVault Debian repository for Ossec',
             location    => 'http://ossec.alienvault.com/repos/apt/debian',

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -27,7 +27,7 @@ class ossec::common {
           #  key_source  => 'http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key',
           #}
 
-          apt::source { 'alienvault-ossec':
+          ::apt::source { 'alienvault-ossec':
             ensure		=> present,
             comment		=> 'This is the AlienVault Ubuntu repository for Ossec',
             location	=> 'http://ossec.alienvault.com/repos/apt/ubuntu',

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -8,9 +8,42 @@ class ossec::common {
 
       case $::lsbdistcodename {
         /(lucid|precise|trusty)/: {
-          $hidsserverservice = 'ossec-hids-server'
-          $hidsserverpackage = 'ossec-hids-server'
-          apt::ppa { 'ppa:nicolas-zin/ossec-ubuntu': }
+          #$hidsserverservice = 'ossec-hids-server'
+          #$hidsserverpackage = 'ossec-hids-server'
+          #apt::ppa { 'ppa:nicolas-zin/ossec-ubuntu': }
+
+          $hidsserverservice = 'ossec'
+          $hidsserverpackage = 'ossec-hids'
+
+          #apt::source { 'alienvault':
+          #  ensure      => present,
+          #  comment     => 'This is the AlienVault Debian repository for Ossec',
+          #  location    => 'http://ossec.alienvault.com/repos/apt/debian',
+          #  release     => $::lsbdistcodename,
+          #  repos       => 'main',
+          #  include_src => false,
+          #  include_deb => true,
+          #  key         => '9A1B1C65',
+          #  key_source  => 'http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key',
+          #}
+
+          apt::source { 'alienvault-ossec':
+            ensure		=> present,
+            comment		=> 'This is the AlienVault Ubuntu repository for Ossec',
+            location	=> 'http://ossec.alienvault.com/repos/apt/ubuntu',
+            release		=> $::lsbdistcodename,
+            repos		=> 'main',
+            key		=> {
+              #id		=> '9A1B1C65',
+              id		=> '9FE55537D1713CA519DFB85114B9C8DB9A1B1C65',
+              source		=> 'http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key',
+            },
+          }
+          ~>
+          exec { 'update-apt-alienvault-repo':
+            command     => '/usr/bin/apt-get update',
+            refreshonly => true
+          }
         }
         /^(jessie|wheezy)$/: {
           $hidsserverservice = 'ossec'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -18,7 +18,7 @@ class ossec::server (
     'Debian' : {
       package { $ossec::common::hidsserverpackage:
         ensure  => installed,
-        require => Apt::Source['alienvault'],
+        require => Apt::Source['alienvault-ossec'],
       }
     }
     'RedHat' : {

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -1,6 +1,10 @@
 <ossec_config>
   <client>
-  <server-ip><%= @ossec_server_ip %></server-ip>
+    <% if @ossec_server_ip =~ /^[1-9].*/ %>
+      <server-ip><%= @ossec_server_ip %></server-ip>
+    <% else -%>
+      <server-hostname><%= @ossec_server_ip %></server-hostname>
+    <% end -%>
   </client>
 
   <syscheck>


### PR DESCRIPTION
Thanks for the updated OSSEC puppet module.

I've made some changes/fixes/updates:
* Use the AlientVault repo for Ubuntu packages as well.
* Changed the name of the apt repo to be a bit more descriptive and in case another alienvault repo is added for another package in the future (this may break compatibility, though).
* If the $::uniqueid fact doesn't exist, run agent_auth on the client to get it to register with the server (of course, requires ossec-authd daemon to be running on the OSSEC server).
* Because of the above bullet point (I think), I was having severe problems with the fail() function in the agentkey.pp file (http://dan.carley.co/blog/2012/10/01/unautomating-with-puppet/ talks about how fail will abort the whole catalog, which was happening to me).
* Lastly, allow the use of server-hostname in the OSSEC agent conf file, in addition to an IP address. As you can see, I'm using a poor mans IP regex test. :-) Feel free to make the regex more rebust.

Hopefully I didn't break any existing functionality. BTW, I don't think the key_source parameter you have in the common.pp for Debian releases will work with newer releases of the apt module. I don't run Debian and can't test it, so didn't change it.