### PR TITLE
Allow configuration of realtime scanning of directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ class { "ossec::client":
  * `$ossec_email_alert_level` (default: 7) It correspond to a threshold (from 0 to 156 to sort alert send by email. Some alerts circumvent this threshold (when they have alert_email option),
  * `$ossec_emailnotification` (default: yes) Whether to send email notifications
  * `$ossec_white_list` Specify array of IP addresses to be whitelisted by OSSEC
+ * `$ossec_scanpaths` Specify hash of paths to scan, with realtime and report_changes (see below for configuration)
 
 
 #### function ossec::email_alert
@@ -107,6 +108,53 @@ About active-response mechanism, check the documentation (and extends the functi
  * `$ossec_active_response` (default: true) allows active response on this host
  * `$ossec_emailnotification` (default: yes) Whether to send email notifications
  * `$selinux` (default: false) Whether to install an SELinux policy to allow rotation of OSSEC logs
+ * `$ossec_scanpaths` Specify hash of paths to scan, with realtime and report_changes (see below for configuration)
+
+### ossec_scanpaths configuration
+
+Leaving this unconfigured will result on OSSEC using the module defaults. By default, it will monitor /etc, /usr/bin, /usr/sbin, /bin and /sbin, with real time monitoring disabled and report_changes enabled.
+
+To overwrite the defaults or add in new paths to scan, you can use hiera to overwrite the defaults.
+
+To tell OSSEC to enable real time monitoring of the default paths:
+```
+ossec::client::ossec_scanpaths:
+  - path: /etc
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /usr/bin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /usr/sbin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /bin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /sbin
+    report_changes: 'yes'
+    realtime: 'yes'
+```
+```
+ossec::server::ossec_scanpaths:
+  - path: /etc
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /usr/bin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /usr/sbin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /bin
+    report_changes: 'yes'
+    realtime: 'yes'
+  - path: /sbin
+    report_changes: 'yes'
+    realtime: 'yes'
+```
+
+**Note: Configuring the ossec_scanpaths variable will overwrite the defaults. i.e. if you want to add a new directory to monitor, you must also add the above default paths to be monitored.**
 
 ## Limitations
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -3,6 +3,7 @@ class ossec::client(
   $ossec_active_response   = true,
   $ossec_server_ip,
   $ossec_emailnotification = 'yes',
+  $ossec_scanpaths = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'no', 'realtime' => 'no'} ],
   $selinux = false,
 ) {
   include ossec::common

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,7 +8,7 @@ class ossec::server (
   $ossec_global_stat_level             = 8,
   $ossec_email_alert_level             = 7,
   $ossec_ignorepaths                   = [],
-  $ossec_scanpaths                     = [],
+  $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'no', 'realtime' => 'no'} ],
   $ossec_white_list                    = [],
   $ossec_emailnotification             = 'yes',
 ) {

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -75,9 +75,7 @@
     <frequency>79200</frequency>
     
     <!-- Directories to check  (perform all possible verifications) -->
-    <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
-<% @ossec_scanpaths.each do |path| -%>    <directories check_all="yes" report_changes="yes" realtime="no"><%= path %></directories>
+<% @ossec_scanpaths.each do |scanpath| -%>    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>"><%= scanpath['path']  %></directories>
 <% end %>
 
     <!-- Files/directories to ignore -->

--- a/templates/10_ossec.conf.erb
+++ b/templates/10_ossec.conf.erb
@@ -73,6 +73,7 @@
   <syscheck>
     <!-- Frequency that syscheck is executed - default to every 22 hours -->
     <frequency>79200</frequency>
+    <alert_new_files>yes</alert_new_files>
     
     <!-- Directories to check  (perform all possible verifications) -->
 <% @ossec_scanpaths.each do |scanpath| -%>    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>"><%= scanpath['path']  %></directories>

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -12,8 +12,8 @@
     <frequency>79200</frequency>
     
     <!-- Directories to check  (perform all possible verifications) -->
-    <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+<% @ossec_scanpaths.each do |scanpath| -%>    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>"><%= scanpath['path']  %></directories>
+<% end %>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/templates/10_ossec_agent.conf.erb
+++ b/templates/10_ossec_agent.conf.erb
@@ -10,6 +10,7 @@
   <syscheck>
     <!-- Frequency that syscheck is executed - default to every 22 hours -->
     <frequency>79200</frequency>
+    <alert_new_files>yes</alert_new_files>
     
     <!-- Directories to check  (perform all possible verifications) -->
 <% @ossec_scanpaths.each do |scanpath| -%>    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>"><%= scanpath['path']  %></directories>


### PR DESCRIPTION
Here's a patch to allow configuration of realtime scanning of directories for OSSEC and also the ability to enable/disable reporting of changes.

Left unconfigured, it should continue to operate in the default manner, meaning it should be non-breaking for people when they upgrade.




