### PR TITLE
Package status

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ class { "ossec::client":
  * `$ossec_emailnotification` (default: yes) Whether to send email notifications
  * `$ossec_white_list` Specify array of IP addresses to be whitelisted by OSSEC
  * `$ossec_scanpaths` Specify hash of paths to scan, with realtime and report_changes (see below for configuration)
+ * `$ossec_package_status` (default: installed) Package status. See https://docs.puppetlabs.com/references/latest/type.html#package-attribute-ensure
 
 
 #### function ossec::email_alert
@@ -109,6 +110,7 @@ About active-response mechanism, check the documentation (and extends the functi
  * `$ossec_emailnotification` (default: yes) Whether to send email notifications
  * `$ossec_scanpaths` Specify hash of paths to scan, with realtime and report_changes (see below for configuration)
  * `$ossec_ip_fact` (default: ::ipaddress) allow override of the fact used to find the client's IP address.  This is useful for when you have multiple IP addresses on a given client and `::ipaddress` returns the incorrect IP for connection to the OSSEC server
+ * `$ossec_package_status` (default: installed) Package status. See https://docs.puppetlabs.com/references/latest/type.html#package-attribute-ensure
 
 ### ossec_scanpaths configuration
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -4,7 +4,8 @@ class ossec::client(
   $ossec_server_ip         = undef,
   $ossec_emailnotification = 'yes',
   $ossec_scanpaths         = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'no', 'realtime' => 'no'} ],
-  $ossec_ip_fact           = '::ipaddress'
+  $ossec_ip_fact           = '::ipaddress',
+  $ossec_package_status    = 'installed'
 ) {
   include ossec::common
 
@@ -13,17 +14,17 @@ class ossec::client(
   case $::osfamily {
     'Debian' : {
       package { $ossec::common::hidsagentpackage:
-        ensure  => installed,
+        ensure  => $ossec_package_status,
         require => Apt::Source['alienvault-ossec'],
       }
     }
     'RedHat' : {
       package { 'ossec-hids':
-        ensure  => installed,
+        ensure  => $ossec_package_status,
         require => Yumrepo['ossec'],
       }
       package { $ossec::common::hidsagentpackage:
-        ensure  => installed,
+        ensure  => $ossec_package_status,
         require => Package['ossec-hids'],
       }
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,7 @@ class ossec::server (
   $ossec_scanpaths                     = [ {'path' => '/etc,/usr/bin,/usr/sbin', 'report_changes' => 'no', 'realtime' => 'no'}, {'path' => '/bin,/sbin', 'report_changes' => 'no', 'realtime' => 'no'} ],
   $ossec_white_list                    = [],
   $ossec_emailnotification             = 'yes',
+  $ossec_package_status                = 'installed'
 ) {
   include ossec::common
   include mysql::client
@@ -19,7 +20,7 @@ class ossec::server (
   case $::osfamily {
     'Debian' : {
       package { $ossec::common::hidsserverpackage:
-        ensure  => installed,
+        ensure  => $ossec_package_status,
         require => Apt::Source['alienvault-ossec'],
       }
     }
@@ -27,19 +28,19 @@ class ossec::server (
       case $::operatingsystem {
         'CentOS' : {
           package { 'ossec-hids':
-            ensure   => installed,
+            ensure   => $ossec_package_status,
           }
           package { $ossec::common::hidsserverpackage:
-            ensure  => installed,
+            ensure  => $ossec_package_status,
             require => Class['mysql::client'],
           }
         }
         'RedHat' : {
           package { 'ossec-hids':
-            ensure   => installed,
+            ensure   => $ossec_package_status,
           }
           package { $ossec::common::hidsserverpackage:
-            ensure  => installed,
+            ensure  => $ossec_package_status,
             require => Class['mysql::client'],
           }
         }


### PR DESCRIPTION
Add ability to set the package status, so you can automatically ensure the package is kept up to date. (A new, bugfix release of OSSEC was released last week.) Set the parameter to 'latest' to ensure the package is kept up to date.

